### PR TITLE
normalize line endings before pattern matching

### DIFF
--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -202,7 +202,7 @@ module.exports = function (grunt) {
 
             file.src.forEach(function (src) {
                 destPath = path.join(dest, path.basename(src));
-                content = grunt.file.read(src).toString();
+                content = grunt.util.normalizelf(grunt.file.read(src).toString());
                 tags = getBuildTags(content);
 
                 tags.forEach(function (tag) {


### PR DESCRIPTION
The tags are parsed from the source document and joined using grunt.util.linefeed(), which is OS-specific.  However, if the source linefeeds are not normalized prior to comparison, they will not be found if the source was authored on a different OS than the grunt task is executing on.

Normalizing the linefeed using grunt.util.normalizelf() at the beginning resolves this bug.
