### PR TITLE
Added replace option

### DIFF
--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -4,30 +4,30 @@
  * Copyright (c) 2013 SPA Tools
  * Code below is licensed under MIT License
  *
- * Permission is hereby granted, free of charge, to any person 
- * obtaining a copy of this software and associated documentation 
- * files (the "Software"), to deal in the Software without restriction, 
- * including without limitation the rights to use, copy, modify, merge, 
- * publish, distribute, sublicense, and/or sell copies of the Software, 
- * and to permit persons to whom the Software is furnished to do so, 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be 
+ *
+ * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
- * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
- * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 module.exports = function (grunt) {
     //#region Global Properties
 
-    var // Init 
+    var // Init
         _ = grunt.util._,
         EOL = grunt.util.linefeed,
         path = require('path'),
@@ -87,7 +87,7 @@ module.exports = function (grunt) {
 
                 delete opt.files;
             }
-            
+
             return grunt.file.expand(opt, files);
         }
     }
@@ -201,7 +201,11 @@ module.exports = function (grunt) {
                 destPath, content, tags;
 
             file.src.forEach(function (src) {
-                destPath = path.join(dest, path.basename(src));
+                if(params.replace) {
+                  destPath = path.join(src);
+                } else {
+                  destPath = path.join(dest, path.basename(src));
+                }
                 content = grunt.file.read(src).toString();
                 tags = getBuildTags(content);
 


### PR DESCRIPTION
Hi,

I've added a replace option that will replace the html file being built rather than write a new file to the root destination path.

Reason being I'm generating my html from markdown to the correct location and just need html-build to updated the assests correctly.
