### PR TITLE
Generate URLs relative to cwd instead of dest

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -2,8 +2,8 @@
     
     <head>
         <title>grunt-html-build - Test Page</title>
-        <link type="text/css" rel="stylesheet" href="../css/libs.css" />
-        <link type="text/css" rel="stylesheet" href="../css/dev.css" />
+        <link type="text/css" rel="stylesheet" href="css/libs.css" />
+        <link type="text/css" rel="stylesheet" href="css/dev.css" />
         <style>
             .this-is-inline {
                 font-weight: bold;
@@ -15,8 +15,8 @@
         <div id="view1">...</div>
         <div id="view2">...</div>
         <div id="view3">...</div>
-        <script type="text/javascript" src="../fixtures/scripts/app.js"></script>
-        <script type="text/javascript" src="../fixtures/scripts/libs.js"></script>
+        <script type="text/javascript" src="fixtures/scripts/app.js"></script>
+        <script type="text/javascript" src="fixtures/scripts/libs.js"></script>
         <script type="text/javascript">
             var version = "0.1.0",
                 title = "test";

--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -124,10 +124,9 @@ module.exports = function (grunt) {
             return processHtmlTagTemplate(options, { content: content }, true);
         }
         else {
-            return options.files.map(function (f) {
-                var url = path.relative(options.dest, f).replace(/\\/g, '/');
+            return options.files.map(function (url) {
                 if (options.prefix) {
-                  url = path.join(options.prefix, url);
+                    url = path.join(options.prefix, url);
                 }
                 return processHtmlTagTemplate(options, { src: url });
             }).join(EOL);


### PR DESCRIPTION
Fixes #13.

The reason i want to do this is that it's fairly easy to move the generated HTML file around so it correctly references the files with absolute paths but you can't with relative.

In our build cycle we generate the HTML file and put it in a folder called public and then we expose that from the root URL (/). The CSS and JS resources are exposed through the /js and /css sub folders but since the html file uses relative paths it can't find them. This solves that.
