### PR TITLE
Ensure correct Path Separator with prefix option

### DIFF
--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -140,11 +140,12 @@ module.exports = function (grunt) {
         else {
             return options.files.map(function (f) {
                 var url = options.relative ? path.relative(options.dest, f) : f;
-                url = url.replace(/\\/g, '/');
 
                 if (options.prefix) {
                     url = path.join(options.prefix, url);
                 }
+                
+                url = url.replace(/\\/g, '/');
 
                 return processHtmlTagTemplate(options, { src: url });
             }).join(EOL);


### PR DESCRIPTION
I've got problems while using the prefix option in a windows env.

Replace the path after joining the prefix with the url solved the problem.
