### PR TITLE
Currently, the tags matched by the build process are removed from the ht...

### DIFF
--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -259,6 +259,11 @@ module.exports = function (grunt) {
                         grunt.fail.warn("Tag with type '" + tag.type + "' and name: '" + tag.name + "' is not configured in your Gruntfile.js !");
                     }
 
+                    // we don't want to remove the tags, otherwise users have to
+                    // re-apply the tags to the html after each successful build
+                    var open = tag.lines[0].replace(/^\s+|\s+$/g, '') + '\n',
+                        close = '\n' + tag.lines.slice(-1)[0].replace(/^\s+|\s+$/g, '');
+
                     content = content.replace(raw, function () { return result });
                 });
 


### PR DESCRIPTION
...ml. This makes for a clean .html file, but leads to the inconvenience of having to re-insert these tags after each build. This small change reapplies the opening and closing tag preceding and trailing the injected <script> tags. This could be integrated into a config, if necessary, but I'm not too familiar with the cascade of code in this task.