### PR TITLE
Allow setting attributes when building elements

### DIFF
--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -39,7 +39,7 @@ module.exports = function (grunt) {
         },
 
         // Tags Regular Expressions
-        regexTagStartTemplate = "<!--\\s*%parseTag%:(\\w+)\\s*(inline)?\\s*(optional)?\\s*([^\\s]*)\\s*-->", // <!-- build:{type} [inline] [optional] {name} --> {} required [] optional
+        regexTagStartTemplate = "<!--\\s*%parseTag%:(\\w+)\\s*(inline)?\\s*(optional)?\\s*([^\\s]*)\\s*(\\[(.*)\\])?.* -->", // <!-- build:{type} [inline] [optional] {name} [ attributes... ] --> {} required [] optional
         regexTagEndTemplate = "<!--\\s*\\/%parseTag%\\s*-->", // <!-- /build -->
         regexTagStart = "",
         regexTagEnd = "",
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
 
             if (tagStart) {
                 tag = true;
-                last = { type: tagStart[1], inline: !!tagStart[2], optional: !!tagStart[3], name: tagStart[4], lines: [] };
+                last = { type: tagStart[1], inline: !!tagStart[2], optional: !!tagStart[3], name: tagStart[4], lines: [], _attributes_: tagStart[6] };
                 tags.push(last);
             }
 
@@ -121,7 +121,7 @@ module.exports = function (grunt) {
 
     function createTemplateData(options, extend) {
         return {
-            data: extend ? _.extend({}, options.data, extend) : options.data
+            data: extend ? _.extend({}, options, options.data, extend) : options.data
         };
     }
     function processTemplate(template, options, extend) {
@@ -158,10 +158,10 @@ module.exports = function (grunt) {
 
     var
         templates = {
-            'script': '<script type="text/javascript" src="<%= src %>"></script>',
-            'script-inline': '<script type="text/javascript"><%= content %></script>',
-            'style': '<link type="text/css" rel="stylesheet" href="<%= src %>" />',
-            'style-inline': '<style><%= content %></style>'
+            'script':           '<script <%= _attributes_ %> type="text/javascript" src="<%= src %>"></script>',
+            'script-inline':    '<script <%= _attributes_ %> type="text/javascript"><%= content %></script>',
+            'style':            '<link <%= _attributes_ %> type="text/css" rel="stylesheet" href="<%= src %>" />',
+            'style-inline':     '<style <%= _attributes_ %>><%= content %></style>'
         },
         validators = {
             script: validateBlockWithName,


### PR DESCRIPTION
When using your builder I had the need to set the `@media` attribute on some compiled elements. It was easy enough to add to your syntax an additional attributes property of the format `[attributes='last item wrapped in square brackets']`.

Add _attributes_ to templates so users can define custom attributes to
set on the processed element

Example from my own code:

```html
<!-- build:style inline small [media="screen and (max-width: 480px)"] -->
<link rel="stylesheet" media="screen and (max-width: 480px)"
type="text/css" href="css/small.css" />
<!-- /build -->
```

Creates a element along the lines of

```html
<style media="screen and (max-width: 480px)">/*stuff*/</style>
```

Issues:

- The regexp I implemented isn't greedy so you cannot have nested brackets in the attributes. Cant think of a single instance where this will be a problem for the supported html elements.