### PR TITLE
Allow loading remote files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,10 @@
                             '<%= fixturesPath %>/scripts/*.js',
                             '!**/main.js',
                         ],
+                        bundle_remote: [
+                            "//cdn.jsdelivr.net/jquery/2.1.0/jquery.js",
+                            "//cdn.jsdelivr.net/bootstrap/3.1.1/js/bootstrap.min.js"
+                        ],
                         main: '<%= fixturesPath %>/scripts/main.js'
                     },
                     styles: {

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
     <script type="text/javascript" src="/path/to/js/app/module1.js"></script>
     <script type="text/javascript" src="/path/to/js/app/module2.js"></script>
     <!-- /build -->
+    <!-- build:script bundle_remote -->
+    <script type="text/javascript" src="//cdn.jsdelivr.net/jquery/2.1.0/jquery.js"></script>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <!-- /build -->
     <!-- build:process -->
     <script type="text/javascript">
         var version = "<%= version %>",

--- a/samples/index.html
+++ b/samples/index.html
@@ -2,8 +2,8 @@
     
     <head>
         <title>grunt-html-build - Test Page</title>
-        <link type="text/css" rel="stylesheet" href="css/libs.css" />
-        <link type="text/css" rel="stylesheet" href="css/dev.css" />
+        <link type="text/css" rel="stylesheet" href="../css/libs.css" />
+        <link type="text/css" rel="stylesheet" href="../css/dev.css" />
         <style>
             .this-is-inline {
                 font-weight: bold;
@@ -15,8 +15,10 @@
         <div id="view1">...</div>
         <div id="view2">...</div>
         <div id="view3">...</div>
-        <script type="text/javascript" src="fixtures/scripts/app.js"></script>
-        <script type="text/javascript" src="fixtures/scripts/libs.js"></script>
+        <script type="text/javascript" src="../fixtures/scripts/app.js"></script>
+        <script type="text/javascript" src="../fixtures/scripts/libs.js"></script>
+        <script type="text/javascript" src="//cdn.jsdelivr.net/jquery/2.1.0/jquery.js"></script>
+        <script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap/3.1.1/js/bootstrap.min.js"></script>
         <script type="text/javascript">
             var version = "0.1.0",
                 title = "test";

--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -102,8 +102,12 @@ module.exports = function (grunt) {
                     files = _.values(src); 
                 }
             }
-
-            return grunt.file.expand(opt, files);
+            if(typeof files !== "object") files = [files];
+            var local = grunt.file.expand(opt, files),
+                remote = _.map(files, path.normalize).filter(function(path) { //for loading from cdn
+                    return /^((http|https):)?(\\|\/\/)/.test(path); //is http, https, or //
+                });
+            return _.uniq(local.concat(remote));
         }
     }
     function validateBlockAlways(tag) {

--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -78,6 +78,13 @@ module.exports = function (grunt) {
 
         return tags;
     }
+    function defaultProcessPath(pathes, opt) { //takes an array of paths and validates them
+        var local = grunt.file.expand(opt, pathes),
+            remote = _.map(pathes, path.normalize).filter(function(path) { //for loading from cdn
+                return /^((http|https):)?(\\|\/\/)/.test(path); //is http, https, or //
+            });
+        return _.uniq(local.concat(remote));
+    }
     function validateBlockWithName(tag, params) {
         var src = params[tag.type + "s"],
 
@@ -103,11 +110,7 @@ module.exports = function (grunt) {
                 }
             }
             if(typeof files !== "object") files = [files];
-            var local = grunt.file.expand(opt, files),
-                remote = _.map(files, path.normalize).filter(function(path) { //for loading from cdn
-                    return /^((http|https):)?(\\|\/\/)/.test(path); //is http, https, or //
-                });
-            return _.uniq(local.concat(remote));
+            return params.processPath(files, opt);
         }
     }
     function validateBlockAlways(tag) {
@@ -216,7 +219,9 @@ module.exports = function (grunt) {
                 styles: {},
                 sections: {},
                 data: {},
-                parseTag: 'build'
+                parseTag: 'build',
+                
+                processPath: defaultProcessPath
             });
 
         setTagRegexes(params.parseTag);


### PR DESCRIPTION
I wanted to decide whether to load files either locally or from a cdn at build time. This pull will always allow external paths (i.e. `https://`, `http://`, or `//`) to validate.

```html
<html>
<head>
    <title>grunt-html-build - Test Page</title>
   <!-- build:script bundle_remote -->
    <script type="text/javascript" src="//cdn.jsdelivr.net/jquery/2.1.0/jquery.js"></script>
    <script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap/3.1.1/js/bootstrap.min.js"></script>
    <!-- /build -->
</head>
<body id="landing-page">
</body>
</html>
```
```js
htmlbuild: {
    dist: {
        src: 'index.html',
        dest: 'samples/',
        options: {
            scripts: {
                bundle_remote: [
                    "//cdn.jsdelivr.net/jquery/2.1.0/jquery.js",
                    "//cdn.jsdelivr.net/bootstrap/3.1.1/js/bootstrap.min.js"
                ]
            }
        }
    }
}
```
Creates
```html
<html>
    
    <head>
        <title>grunt-html-build - Test Page</title>
        <script type="text/javascript" src="//cdn.jsdelivr.net/jquery/2.1.0/jquery.js"></script>
        <script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap/3.1.1/js/bootstrap.min.js"></script>
    </head>
    
    <body id="landing-page">
    </body>
</html>
```

Also added a option `processPath` which can be used to specify how paths will be determined to exist. For instance an updated config from the readme may look like this if theyre using the default `processPath` handler

```javascript
grunt.initConfig({
    fixturesPath: "fixtures",

    htmlbuild: {
        dist: {
            src: 'index.html',
            dest: 'samples/',
            options: {
                beautify: true,
                prefix: '//some-cdn',
				relative: true,
                scripts: {
                    bundle: [
                        '<%= fixturesPath %>/scripts/*.js',
                        '!**/main.js',
                    ],
                    main: '<%= fixturesPath %>/scripts/main.js'
                },
                styles: {
                    bundle: [
                        '<%= fixturesPath %>/css/libs.css',
                        '<%= fixturesPath %>/css/dev.css'
                    ],
                    test: '<%= fixturesPath %>/css/inline.css'
                },
                sections: {
                    views: '<%= fixturesPath %>/views/**/*.html',
                    templates: '<%= fixturesPath %>/templates/**/*.html',
					layout: {
						header: '<%= fixturesPath %>/layout/header.html',
						footer: '<%= fixturesPath %>/layout/footer.html'
					}
                },
                data: {
					// Data to pass to templates
                    version: "0.1.0",
                    title: "test",
                },
                
                //Default process path (filers files based by whether relative path exists or path appears to be an http request (http://url, https://url or //url)
                processPath: function defaultProcessPath(pathes, opt) { //takes an array of paths and validates them
                    var local = grunt.file.expand(opt, pathes),
                        remote = _.map(pathes, path.normalize).filter(function(path) { //for loading from cdn
                            return /^((http|https):)?(\\|\/\/)/.test(path); //is http, https, or //
                        });
                    return _.uniq(local.concat(remote));
                }
            }
        }
    }
});
```