### PR TITLE
Fixed bug in relative path generation for scripts and styles.

### DIFF
--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -140,7 +140,7 @@ module.exports = function (grunt) {
         }
         else {
             return options.files.map(function (f) {
-                var url = options.relative ? path.relative(options.dest, f) : f;
+                var url = options.relative ? path.relative(path.dirname(options.dest), f) : f;
                 
                 url = url.replace(/\\/g, '/');
 


### PR DESCRIPTION
Relative path generation appears broken, and will always generate an unnecessary leading "../" for style and script resources.

For example, I have the following structure:
- project/
  - dist/
    - release/
      - index.html <= generated by grunt-html-build
      - css/
        - main.css <= referenced, relative file
      - js/
        - main.js <= referenced, relative file

The relative path from index.html to main.css should be "css/main.css". Similarly, the relative path to main.js should be "js/main.js". However, grunt-html-build generates the relative paths as "../css/main.css" and "../js/main.js", respectively. 

This happens because when using path.relative(file1, file2), the "file1" parameter also contains the filename. If we change file1 to path.dirname(file1), the correct paths are generated. Here's an example:

```
var path = require('path');
var result = path.relative('./dist/debug/index.html', './dist/debug/js/main.js');
console.log(result); // <= ../js/main.js (INCORRECT)
```

However, if we use dirname instead, we get the correct relative path:

```
var path = require('path');
var result = path.relative(path.dirname('./dist/debug/index.html'), './dist/debug/js/main.js');
console.log(result); // <= js/main.js (CORRECT)
```

If this 
