### PR TITLE
fix(readme): typo in folder name for generated HTML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Using the configuration above, consider the following example html to see it in 
 </html>
 ```
 
-After running the grunt task it will be stored on the dist folder as
+After running the grunt task it will be stored on the samples folder as
 
 ```html
 <html>


### PR DESCRIPTION
The plugin config specifies output folder as `samples` , whereas a later reference in the file says that the output will be generated in `dist` folder