### PR TITLE
detect line endings based on text not on OS

### DIFF
--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -287,8 +287,17 @@ module.exports = function (grunt) {
         var tags = getBuildTags(content),
             config = grunt.config();
 
+        function detectLineEnding(line) {
+            if (line.indexOf('\r\n') !== -1) {
+                return '\r\n';
+            }
+            else {
+                return '\n';
+            }
+        }
+
         tags.forEach(function (tag) {
-            var raw = tag.lines.join(EOL),
+            var raw = tag.lines.join(detectLineEnding(tag.lines[0])),
                 result = "",
                 tagFiles = validators.validate(tag, params);
 


### PR DESCRIPTION
Hello i made a fix to detect the line endings inside the text and not based on the OS Platform.
regards, the new method is 'detectLineEnding()' and will be used in ' transformContent(content, params, dest)'
Thanks for merging
Regards