### PR TITLE
Fixed: broken inlining for scripts containing $x

### DIFF
--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -187,8 +187,14 @@ module.exports = function (grunt) {
 
         if (!options.inline || options.noprocess) {
             return template
-                    .replace("<%= src %>", src)
-                    .replace("<%= attributes %>", attrs);
+                    .replace(/\<\%\= (src|attributes) \%\>/g, function(match, p1) {
+                        if(p1 == 'src') {
+                            return src;
+                        }
+                        else if(p1 == 'attributes') {
+                            return attrs;
+                        }
+                    });
         }
         else {
             return processTemplate(template, options, src, attrs);


### PR DESCRIPTION
Scripts that contained special sequences such as `$$`, `$&` etc were broken when inlined. Fixes #77