### PR TITLE
Add option for using processed file names

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,10 @@
-﻿module.exports = function (grunt) {
+module.exports = function (grunt) {
     grunt.initConfig({
         fixturesPath: "fixtures",
 
         htmlbuild: {
             dist: {
-                src: './index.html',
+                src: './*.html',
                 dest: './samples/',
                 options: {
                     beautify: true,
@@ -12,6 +12,7 @@
                     //parseTag: 'htmlbuild',
                     // keepTags: true,
                     relative: true,
+                    useFileName: true,
                     scripts: {
                         bundle: [
                             '<%= fixturesPath %>/scripts/*.js',
@@ -33,7 +34,8 @@
                                 'css/another.less'
                             ]
                         },
-                        test: '<%= fixturesPath %>/css/inline.css'
+                        test: '<%= fixturesPath %>/css/inline.css',
+                        pageSpecific: '<%= fixturesPath %>/css/_CURRENT_FILE_NAME_.inline.css'
                     },
                     sections: {
                         views: '<%= fixturesPath %>/views/**/*.html',

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,4 +1,4 @@
-﻿# grunt-html-build
+# grunt-html-build
 
 ## Task Options
 
@@ -212,3 +212,12 @@ Format : <!-- {options.parseTag}:{scripts|styles|sections|process|remove} {name}
  **default:** *autodectect*
 
 Force output EOL. If not specified, it will be detected from the input file.
+
+
+### options.useFileName
+
+**type :** boolean |
+**optional** |
+**default:** false
+
+Set to enable replacing _CURRENT_FILE_NAME_ in src for each file processed during build

--- a/example.html
+++ b/example.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Specific Inline Example</title>
+</head>
+<!-- build:style inline pageSpecific -->
+<!-- /build -->
+<body>
+  
+</body>
+</html>

--- a/fixtures/css/example.inline.css
+++ b/fixtures/css/example.inline.css
@@ -1,0 +1,3 @@
+.this-is-example-inline {
+    font-style: italic;
+}

--- a/fixtures/css/index.inline.css
+++ b/fixtures/css/index.inline.css
@@ -1,0 +1,3 @@
+.this-is-index-inline {
+  background: red;
+}

--- a/fixtures/css/inline.css
+++ b/fixtures/css/inline.css
@@ -1,3 +1,3 @@
-﻿.this-is-inline {
+.this-is-inline {
     font-weight: bold;
 }

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-﻿<html>
+<html>
 <head>
     <title>grunt-html-build - Test Page</title>
     <!-- build:style bundle -->
@@ -12,6 +12,8 @@
     <!-- /build -->
     <!-- build:style inline test [media="screen and (max-width: 480px)"] -->
     <link rel="stylesheet" type="text/css" href="/path/to/css/dev-inline.css" />
+    <!-- /build -->
+    <!-- build:style inline pageSpecific -->
     <!-- /build -->
 </head>
 <body id="landing-page">

--- a/samples/example.html
+++ b/samples/example.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Page Specific Inline Example</title>
+</head>
+<style>
+    .this-is-example-inline {
+        font-style: italic;
+    }
+</style>
+
+<body>
+
+</body>
+
+</html>

--- a/samples/index.html
+++ b/samples/index.html
@@ -18,12 +18,20 @@
             font-weight: bold;
         }
     </style>
+    <style>
+        .this-is-index-inline {
+            background: red;
+        }
+    </style>
 </head>
 
 <body id="landing-page">
     <div id="view-recursive">
         <!-- build:process -->
-        <h1><%= title %> - <%= version %></h1>
+        <h1>
+            <%= title %> -
+                <%= version %>
+        </h1>
         <!-- /build -->
     </div>
 

--- a/tasks/build-html.js
+++ b/tasks/build-html.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * grunt-html-build
  * https://github.com/spatools/grunt-html-build
  * Copyright (c) 2013 SPA Tools
@@ -43,7 +43,8 @@ module.exports = function (grunt) {
         regexTagEndTemplate = "<!--\\s*\\/%parseTag%\\s*-->", // <!-- /build -->
         regexTagStart = "",
         regexTagEnd = "",
-        isFileRegex = /\.(\w+){2,4}$/;
+        isFileRegex = /\.(\w+){2,4}$/,
+        processedFile = "";
 
     //#endregion
 
@@ -111,6 +112,11 @@ module.exports = function (grunt) {
         }
 
         if (src) {
+            // check if we want to use current file name, if so update src where necessary
+            if( params.useFileName && src.toString().match(/_CURRENT_FILE_NAME_/g) ) {
+              src = src.toString().replace("_CURRENT_FILE_NAME_", processedFile);
+            }
+          
             var opt = {},
                 files = src;
 
@@ -363,6 +369,7 @@ module.exports = function (grunt) {
             relative: true,
             basePath: false,
             keepTags: false,
+            useFileName: false,
             scripts: {},
             styles: {},
             sections: {},
@@ -378,6 +385,9 @@ module.exports = function (grunt) {
                 destPath, content;
 
             file.src.forEach(function (src) {
+                // update with the name of the file currently being processed
+                processedFile = src.match(/(?!.+\/).+(?=\.)/g).toString().replace("/", "");
+              
                 // replace files in the same folder
                 if (params.replace) {
                     destPath = src;


### PR DESCRIPTION
With useFileName true, it will replace instances of
'_CURRENT_FILE_NAME_' in the sourced files during the build process.
One single grunt line can handle all inline CSS files for each HTML file
processed while keeping page specific files separate.

An example.html file was also included to demonstrate how it works with
the same build line in multiple HTML files. This following build line in
both index.html and example.html will include their relevant inline.css
files.

<!-- build:style inline pageSpecific -->
<!-- /build -->